### PR TITLE
Fix NamedPipeTransport resource cleanup

### DIFF
--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/NamedPipeTransport.cs
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/NamedPipeTransport.cs
@@ -84,6 +84,8 @@ public sealed class NamedPipeTransport(string pipeName, bool isServer) : IMessag
     public async Task StopProcessingAsync()
     {
         _cts?.Cancel();
+        _stream?.Dispose();
+        _cts?.Dispose();
         await Task.Yield();
     }
 }


### PR DESCRIPTION
## Summary
- dispose underlying NamedPipe stream and CancellationTokenSource

## Testing
- `dotnet build Semantic.Kernel.Agent2AgentProtocol.Example.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6882ae72e37c832cb80a450fe609228c