### PR TITLE
Add cancellation tokens and logging to transports

### DIFF
--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Agent1/Agent1.cs
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Agent1/Agent1.cs
@@ -7,7 +7,7 @@ public class Agent1(IMessagingTransport transport)
 {
     private readonly IMessagingTransport _transport = transport;
 
-    public async Task RunAsync()
+    public async Task RunAsync(CancellationToken cancellationToken = default)
     {
         Console.WriteLine("[Agent‑1] starting and listening...");
 
@@ -16,9 +16,9 @@ public class Agent1(IMessagingTransport transport)
         {
             Console.WriteLine($"[Agent‑1] ← {json}");
             await Task.CompletedTask;
-        });
+        }, cancellationToken);
 
-        await Task.Delay(2_000); // ensure Agent‑2 listener is ready
+        await Task.Delay(2_000, cancellationToken); // ensure Agent‑2 listener is ready
 
         Console.WriteLine("[Agent‑1] → sending REVERSE task...");
         var jsonRequest = A2AHelper.BuildTaskRequest("reverse: hello from Agent 1", "Agent1", "Agent2");

--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Agent2/Agent2.cs
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Agent2/Agent2.cs
@@ -8,7 +8,7 @@ public class Agent2(IMessagingTransport transport, Microsoft.SemanticKernel.Kern
 {
     private readonly IMessagingTransport _transport = transport;
 
-    public async Task RunAsync()
+    public async Task RunAsync(CancellationToken cancellationToken = default)
     {
         Console.WriteLine("[Agent‑2] waiting for task...");
 
@@ -46,7 +46,7 @@ public class Agent2(IMessagingTransport transport, Microsoft.SemanticKernel.Kern
 
             var responseJson = A2AHelper.BuildTaskRequest(result, "Agent2", from ?? string.Empty);
             await _transport.SendMessageAsync(responseJson);
-        });
+        }, cancellationToken);
 
         Console.ReadLine();
         await _transport.StopProcessingAsync();

--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/AzureServiceBusTransport.cs
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/AzureServiceBusTransport.cs
@@ -1,5 +1,6 @@
 using Azure.Messaging.ServiceBus;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 
 namespace Semantic.Kernel.Agent2AgentProtocol.Example.Core.Messaging;
 
@@ -9,7 +10,7 @@ namespace Semantic.Kernel.Agent2AgentProtocol.Example.Core.Messaging;
 /// The queue name is used symmetrically by *both* agents – the <paramref name="isReceiver"/> flag merely
 /// decides which side sets up the <see cref="ServiceBusProcessor"/>.
 /// </summary>
-public sealed class AzureServiceBusTransport(string connectionString, string queueName, bool isReceiver)
+public sealed class AzureServiceBusTransport(string connectionString, string queueName, bool isReceiver, ILogger<AzureServiceBusTransport>? logger = null)
     : IMessagingTransport
 {
     private readonly ServiceBusClient _client = new(connectionString);
@@ -19,11 +20,14 @@ public sealed class AzureServiceBusTransport(string connectionString, string que
     private ServiceBusSender? _sender;
     private ServiceBusProcessor? _processor;
     private Func<string, Task>? _handler;
+    private readonly ILogger<AzureServiceBusTransport>? _logger = logger;
+    private CancellationTokenSource? _cts;
 
-    public async Task StartProcessingAsync(Func<string, Task> onMessageReceived)
+    public async Task StartProcessingAsync(Func<string, Task> onMessageReceived, CancellationToken cancellationToken)
     {
         _handler = onMessageReceived;
         _sender = _client.CreateSender(_queueName);
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         if (_isReceiver)
         {
@@ -39,11 +43,13 @@ public sealed class AzureServiceBusTransport(string connectionString, string que
                 try
                 {
                     JsonDocument.Parse(json);
+                    _logger?.LogDebug("Received JSON: {json}", json);
                     if (_handler != null) await _handler(json);
                 }
                 catch (JsonException)
                 {
                     // Ignore malformed payloads
+                    _logger?.LogWarning("Received malformed JSON");
                 }
 
                 await args.CompleteMessageAsync(args.Message);
@@ -55,20 +61,38 @@ public sealed class AzureServiceBusTransport(string connectionString, string que
                 return Task.CompletedTask;
             };
 
-            await _processor.StartProcessingAsync();
+            await _processor.StartProcessingAsync(_cts.Token);
         }
     }
 
     public async Task SendMessageAsync(string json)
     {
         _sender ??= _client.CreateSender(_queueName);
-        var message = new ServiceBusMessage(json);
+        var message = new ServiceBusMessage(json)
+        {
+            ContentType = "application/json"
+        };
+        try
+        {
+            var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("id", out var idProperty))
+            {
+                message.CorrelationId = idProperty.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            _logger?.LogWarning("Malformed JSON when sending");
+        }
         await _sender.SendMessageAsync(message);
+        _logger?.LogDebug("Sent JSON: {json}", json);
     }
 
     public async Task StopProcessingAsync()
     {
+        _cts?.Cancel();
         if (_processor != null) await _processor.StopProcessingAsync();
         await _client.DisposeAsync();
+        _cts?.Dispose();
     }
 }

--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/IMessagingTransport.cs
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/IMessagingTransport.cs
@@ -11,7 +11,7 @@ namespace Semantic.Kernel.Agent2AgentProtocol.Example.Core.Messaging
         /// Starts listening for incoming A2A messages and invokes the supplied delegate for each
         /// fully received JSON payload.
         /// </summary>
-        Task StartProcessingAsync(Func<string, Task> onMessageReceived);
+    Task StartProcessingAsync(Func<string, Task> onMessageReceived, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sends the specified raw JSON payload through the underlying transport.

--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Semantic.Kernel.Agent2AgentProtocol.Example.Core.csproj
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Semantic.Kernel.Agent2AgentProtocol.Example.Core.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="a2a-net.Client" Version="0.10.0" />
     <PackageReference Include="a2a-net.Client.Http" Version="0.10.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.60.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- make StartProcessingAsync accept a cancellation token
- wire `ILogger` into NamedPipeTransport and AzureServiceBusTransport
- propagate ContentType and CorrelationId when sending Service Bus messages
- add logging setup to sample agents
- plumb cancellation tokens from agents down into transports
- add logging package reference

## Testing
- `dotnet restore`
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_6882b012a038832c93ca40b68a178aa4