### PR TITLE
Improve transport and configuration

### DIFF
--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/NamedPipeTransport.cs
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/NamedPipeTransport.cs
@@ -79,9 +79,10 @@ public sealed class NamedPipeTransport(string pipeName, bool isServer, ILogger<N
 
     public async Task SendMessageAsync(string json)
     {
-        if (_stream == null) return;
+        if (_stream is not { CanWrite: true })
+            throw new InvalidOperationException("Pipe not connected.");
 
-        var writer = new StreamWriter(_stream, Encoding.UTF8) { AutoFlush = true };
+        await using var writer = new StreamWriter(_stream, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
         await writer.WriteLineAsync(json);
         _logger?.LogDebug("Sent JSON: {json}", json);
     }

--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/TransportOptions.cs
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/TransportOptions.cs
@@ -1,0 +1,22 @@
+namespace Semantic.Kernel.Agent2AgentProtocol.Example.Core.Messaging;
+
+/// <summary>
+/// Configuration options for selecting and configuring the messaging transport.
+/// </summary>
+public class TransportOptions
+{
+    /// <summary>
+    /// Use Azure Service Bus instead of named pipes.
+    /// </summary>
+    public bool UseAzure { get; set; }
+
+    /// <summary>
+    /// Connection string used when <see cref="UseAzure"/> is <c>true</c>.
+    /// </summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Queue name for Azure Service Bus or pipe name for named pipes.
+    /// </summary>
+    public string QueueOrPipeName { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- add `TransportOptions` for messaging configuration
- update programs to use options pattern
- verify pipe connection before sending

## Testing
- `dotnet restore Semantic.Kernel.Agent2AgentProtocol.Example.sln`
- `dotnet build Semantic.Kernel.Agent2AgentProtocol.Example.sln -c Release --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_6882b3237f9c832c8470e2b01608488b