### PR TITLE
Update sample to use a2a-dotnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Semantic Kernel A2A Protocol Example
+
+This repository demonstrates a simple agent-to-agent conversation using the [a2a-dotnet](https://github.com/a2aproject/a2a-dotnet) SDK.
+
+Two console applications (`Agent1` and `Agent2`) exchange A2A JSON-RPC messages over either a named pipe or an Azure Service Bus queue. `Agent2` performs very simple text processing using [Semantic Kernel](https://github.com/microsoft/semantic-kernel) and replies to the sender.
+
+## Prerequisites
+
+- .NET 8.0 SDK
+- Optional: Azure Service Bus connection string if you want to use Service Bus instead of named pipes.
+
+## Running the demo
+
+1. Build the solution:
+   ```bash
+   dotnet build
+   ```
+2. Start Agent2 (the responder):
+   ```bash
+   dotnet run --project Semantic.Kernel.Agent2AgentProtocol.Example.Agent2
+   ```
+3. Start Agent1 in a second terminal:
+   ```bash
+   dotnet run --project Semantic.Kernel.Agent2AgentProtocol.Example.Agent1
+   ```
+
+You should see the agents exchange a `reverse` command. Agent2 reverses the supplied text and streams the response back to Agent1 using the A2A protocol.
+
+## New features
+
+This version uses the `a2a-dotnet` library which provides:
+
+- **A2AClient** for sending JSON‑RPC requests and receiving streaming responses.
+- **TaskManager** for managing long running tasks and updating their status.
+- Strongly typed models such as `Message` and `TextPart` for constructing requests and parsing replies.
+
+Both streaming and task management are supported by the library and can be enabled by adjusting the helper and transport implementations.

--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Semantic.Kernel.Agent2AgentProtocol.Example.Core.csproj
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Semantic.Kernel.Agent2AgentProtocol.Example.Core.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="a2a-net.Client" Version="0.10.0" />
-    <PackageReference Include="a2a-net.Client.Http" Version="0.10.0" />
+    <PackageReference Include="A2A" Version="0.1.0-preview.1" />
+    <PackageReference Include="A2A.AspNetCore" Version="0.1.0-preview.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.60.0" />


### PR DESCRIPTION
## Summary
- switch example to reference `A2A` packages
- rebuild `A2AHelper` to use `Message` and friends from the new SDK
- add a short README with instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68875943adf8832c9e15fe65ce4e8693