### PR TITLE
Switch to A2A NuGet packages

### DIFF
--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Core/A2A/A2AHelper.cs
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Core/A2A/A2AHelper.cs
@@ -1,78 +1,78 @@
-using Microsoft.Agents.Core.Models;
-using Microsoft.Agents.Core.Serialization;
+using System.Text.Json;
+using A2A;
+using System.Linq;
 
 namespace Semantic.Kernel.Agent2AgentProtocol.Example.Core.A2A;
 
 /// <summary>
-/// Helper methods for creating and parsing Activity Protocol payloads.
+/// Helper methods for creating and parsing A2A protocol payloads.
 /// </summary>
 public static class A2AHelper
 {
-    private const string ConversationId = "a2a-demo";
+    private static readonly JsonSerializerOptions s_options = A2AJsonUtilities.DefaultOptions;
 
     /// <summary>
-    /// Build an Activity message describing this agent's capabilities using a Hero card.
+    /// Build an <see cref="AgentCard"/> describing this agent's capabilities.
     /// </summary>
     public static string BuildCapabilitiesCard(string from, string to)
     {
-        var card = new HeroCard
+        var card = new AgentCard
         {
-            Title = "Agent capabilities",
-            Buttons =
+            Name = from,
+            Description = "Agent capabilities",
+            Url = $"https://{from}.a2a.local/",
+            Version = "1.0.0",
+            Capabilities = new AgentCapabilities(),
+            DefaultInputModes = ["text"],
+            DefaultOutputModes = ["text"],
+            Skills =
             [
-                new CardAction(type: ActionTypes.MessageBack, title: "reverse", value: "reverse"),
-                new CardAction(type: ActionTypes.MessageBack, title: "upper", value: "upper")
+                new AgentSkill { Id = "reverse", Name = "reverse", Description = "Reverse text", Tags = [] },
+                new AgentSkill { Id = "upper", Name = "upper", Description = "Uppercase text", Tags = [] }
             ]
         };
 
-        var activity = new Activity
-        {
-            Type = ActivityTypes.Message,
-            Id = Guid.NewGuid().ToString(),
-            Timestamp = DateTimeOffset.UtcNow,
-            From = new ChannelAccount(id: from),
-            Recipient = new ChannelAccount(id: to),
-            Conversation = new ConversationAccount(id: ConversationId),
-            Attachments = [card.ToAttachment()]
-        };
-
-        return ProtocolJsonSerializer.ToJson(activity);
+        return JsonSerializer.Serialize(card, s_options);
     }
 
     /// <summary>
-    /// Build an Activity message used to send a text task.
+    /// Build a <see cref="Message"/> used to send a text task.
     /// </summary>
     public static string BuildTaskRequest(string text, string from, string to)
     {
-        var activity = new Activity
+        var message = new Message
         {
-            Type = ActivityTypes.Message,
-            Id = Guid.NewGuid().ToString(),
-            Timestamp = DateTimeOffset.UtcNow,
-            From = new ChannelAccount(id: from),
-            Recipient = new ChannelAccount(id: to),
-            Conversation = new ConversationAccount(id: ConversationId),
-            Text = text
+            Role = MessageRole.Agent,
+            MessageId = Guid.NewGuid().ToString(),
+            Parts = [new TextPart { Text = text }],
+            Metadata = new Dictionary<string, JsonElement>
+            {
+                ["from"] = JsonSerializer.SerializeToElement(from, s_options),
+                ["to"] = JsonSerializer.SerializeToElement(to, s_options)
+            }
         };
 
-        return ProtocolJsonSerializer.ToJson(activity);
+        return JsonSerializer.Serialize(message, s_options);
     }
 
     /// <summary>
-    /// Parse an Activity message looking for a text task request.
+    /// Parse a message looking for a text task request.
     /// Returns (null, null, null) if the payload isn't a valid message.
     /// </summary>
     public static (string? text, string? from, string? to) ParseTaskRequest(string json)
     {
         try
         {
-            Activity activity = ProtocolJsonSerializer.ToObject<Activity>(json);
-            if (activity.Type != ActivityTypes.Message || string.IsNullOrWhiteSpace(activity.Text))
-            {
-                return (null, null, null);
-            }
+            Message message = JsonSerializer.Deserialize<Message>(json, s_options)!;
+            string? text = message.Parts.OfType<TextPart>().FirstOrDefault()?.Text;
+            string? from = message.Metadata != null && message.Metadata.TryGetValue("from", out JsonElement fromElem)
+                ? fromElem.GetString()
+                : null;
+            string? to = message.Metadata != null && message.Metadata.TryGetValue("to", out JsonElement toElem)
+                ? toElem.GetString()
+                : null;
 
-            return (activity.Text, activity.From?.Id, activity.Recipient?.Id);
+            return text != null ? (text, from, to) : (null, null, null);
         }
         catch
         {
@@ -81,36 +81,16 @@ public static class A2AHelper
     }
 
     /// <summary>
-    /// Parse a capabilities card and return the set of declared actions along with the sender id.
+    /// Parse a capabilities card and return the set of declared skills along with the agent name.
     /// Returns null if the payload isn't a capabilities card.
     /// </summary>
     public static (IList<string>? capabilities, string? from) ParseCapabilityCard(string json)
     {
         try
         {
-            Activity activity = ProtocolJsonSerializer.ToObject<Activity>(json);
-            if (activity.Attachments == null || activity.Attachments.Count == 0)
-            {
-                return (null, null);
-            }
-
-            List<string> capabilities = new();
-            foreach (Attachment? attachment in activity.Attachments)
-            {
-                if (attachment.ContentType == HeroCard.ContentType)
-                {
-                    HeroCard card = ProtocolJsonSerializer.ToObject<HeroCard>(attachment.Content);
-                    foreach (CardAction? button in card.Buttons)
-                    {
-                        if (button?.Value != null)
-                        {
-                            capabilities.Add(button.Value.ToString()!);
-                        }
-                    }
-                }
-            }
-
-            return capabilities.Count > 0 ? (capabilities, activity.From?.Id) : (null, null);
+            AgentCard card = JsonSerializer.Deserialize<AgentCard>(json, s_options)!;
+            IList<string> capabilities = card.Skills.Select(skill => skill.Id).ToList();
+            return capabilities.Count > 0 ? (capabilities, card.Name) : (null, null);
         }
         catch
         {

--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Semantic.Kernel.Agent2AgentProtocol.Example.Core.csproj
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Semantic.Kernel.Agent2AgentProtocol.Example.Core.csproj
@@ -9,8 +9,9 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Agents.Core" Version="1.2.29-beta" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.61.0" />
+    <PackageReference Include="A2A" Version="0.1.0-preview.2" />
+    <PackageReference Include="A2A.AspNetCore" Version="0.1.0-preview.2" />
   </ItemGroup>
 
 


### PR DESCRIPTION
## Summary
- use A2A NuGet packages in core project
- replace custom Activity-based helper with A2A agent card and message handling

## Testing
- `dotnet build Semantic.Kernel.Agent2AgentProtocol.Example.sln`


------
https://chatgpt.com/codex/tasks/task_e_688fd1890ff4832c89a4063c9fcbf4c7