### PR TITLE
Fix discovery service registration binding

### DIFF
--- a/Agent2AgentProtocol.Discovery.Service/CapabilityRegistration.cs
+++ b/Agent2AgentProtocol.Discovery.Service/CapabilityRegistration.cs
@@ -1,0 +1,8 @@
+namespace Agent2AgentProtocol.Discovery.Service;
+
+public class CapabilityRegistration
+{
+    public AgentCapability Capability { get; set; } = new();
+    public AgentEndpoint Endpoint { get; set; } = new();
+}
+

--- a/Agent2AgentProtocol.Discovery.Service/Program.cs
+++ b/Agent2AgentProtocol.Discovery.Service/Program.cs
@@ -5,9 +5,9 @@ builder.Services.AddSingleton<ICapabilityRegistry, InMemoryCapabilityRegistry>()
 
 var app = builder.Build();
 
-app.MapPost("/register", (AgentCapability capability, AgentEndpoint endpoint, ICapabilityRegistry registry) =>
+app.MapPost("/register", (CapabilityRegistration registration, ICapabilityRegistry registry) =>
 {
-    registry.RegisterCapability(capability, endpoint);
+    registry.RegisterCapability(registration.Capability, registration.Endpoint);
     return Results.Ok();
 });
 


### PR DESCRIPTION
## Summary
- allow registering capabilities and endpoints with a single request object
- adjust discovery service to unpack the registration object

## Testing
- `dotnet test`
- `dotnet run --project Agent2AgentProtocol.Discovery.Service`

------
https://chatgpt.com/codex/tasks/task_e_688fe2eb9fd4832cb3872c628a07dd0a