### PR TITLE
Fix discovery service port

### DIFF
--- a/Agent2AgentProtocol.Discovery.Service/Program.cs
+++ b/Agent2AgentProtocol.Discovery.Service/Program.cs
@@ -1,6 +1,7 @@
 using Agent2AgentProtocol.Discovery.Service;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.UseUrls("http://localhost:5000");
 builder.Services.AddSingleton<ICapabilityRegistry, InMemoryCapabilityRegistry>();
 
 var app = builder.Build();


### PR DESCRIPTION
## Summary
- ensure discovery service binds to port 5000 so agents can connect

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_688fe5b164f4832c9bbad09e7ba0328a