### PR TITLE
Fix typo in Agent1 response log

### DIFF
--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Agent1/Agent1.cs
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Agent1/Agent1.cs
@@ -17,7 +17,7 @@ public class Agent1(IMessagingTransport transport)
             (string? text, _, _) = A2AHelper.ParseTaskRequest(json);
             if (text != null)
             {
-                Console.WriteLine($"[Agent‑1] recieved response from another agent ← '{text}'");
+                Console.WriteLine($"[Agent‑1] received response from another agent ← '{text}'");
             }
 
             await Task.CompletedTask;


### PR DESCRIPTION
## Summary
- fix typo in Agent1 response logging string

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688ff3bdbce8832ca110d7383c10a23a