### PR TITLE
Implement async disposal for transports

### DIFF
--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/AzureServiceBusTransport.cs
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/AzureServiceBusTransport.cs
@@ -90,8 +90,31 @@ public sealed class AzureServiceBusTransport(string connectionString, string que
 
     public async Task StopProcessingAsync()
     {
-        if(_cts != null) await _cts.CancelAsync();
-        if (_processor != null) await _processor.StopProcessingAsync();
+        if (_cts != null)
+        {
+            await _cts.CancelAsync();
+        }
+
+        if (_processor != null)
+        {
+            await _processor.StopProcessingAsync();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopProcessingAsync();
+
+        if (_sender != null)
+        {
+            await _sender.DisposeAsync();
+        }
+
+        if (_processor != null)
+        {
+            await _processor.DisposeAsync();
+        }
+
         await _client.DisposeAsync();
         _cts?.Dispose();
     }

--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/IMessagingTransport.cs
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/IMessagingTransport.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Semantic.Kernel.Agent2AgentProtocol.Example.Core.Messaging
 {
     /// <summary>
@@ -5,7 +7,7 @@ namespace Semantic.Kernel.Agent2AgentProtocol.Example.Core.Messaging
     /// over a specific medium (e.g., named pipes, Azure Service Bus, WebSockets).
     /// The transport remains message‑shape agnostic: it only deals with raw JSON payloads.
     /// </summary>
-    public interface IMessagingTransport
+    public interface IMessagingTransport : IAsyncDisposable
     {
         /// <summary>
         /// Starts listening for incoming A2A messages and invokes the supplied delegate for each

--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/NamedPipeTransport.cs
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Core/Messaging/NamedPipeTransport.cs
@@ -18,6 +18,8 @@ public sealed class NamedPipeTransport(string pipeName, bool isServer, ILogger<N
     private readonly ILogger<NamedPipeTransport>? _logger = logger;
     private Func<string, Task>? _handler;
     private CancellationTokenSource? _cts;
+    private StreamWriter? _writer;
+    private Task? _readLoopTask;
 
     public async Task StartProcessingAsync(Func<string, Task> onMessageReceived, CancellationToken cancellationToken)
     {
@@ -48,7 +50,8 @@ public sealed class NamedPipeTransport(string pipeName, bool isServer, ILogger<N
             _stream = client;
         }
 
-        _ = Task.Run(ReadLoopAsync, _cts.Token); // fire‑and‑forget
+        _writer = new StreamWriter(_stream, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
+        _readLoopTask = Task.Run(ReadLoopAsync, _cts.Token);
     }
 
     private async Task ReadLoopAsync()
@@ -81,16 +84,37 @@ public sealed class NamedPipeTransport(string pipeName, bool isServer, ILogger<N
         if (_stream is not { CanWrite: true })
             throw new InvalidOperationException("Pipe not connected.");
 
-        await using var writer = new StreamWriter(_stream, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
-        await writer.WriteLineAsync(json);
+        _writer ??= new StreamWriter(_stream, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
+        await _writer.WriteLineAsync(json);
         _logger?.LogDebug("Sent JSON: {json}", json);
     }
 
     public async Task StopProcessingAsync()
     {
-        if (_cts != null) await _cts.CancelAsync();
-        if(_stream != null) await _stream.DisposeAsync();
+        if (_cts != null)
+        {
+            await _cts.CancelAsync();
+        }
+
+        if (_readLoopTask != null)
+        {
+            await _readLoopTask;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopProcessingAsync();
+        if (_writer != null)
+        {
+            await _writer.DisposeAsync();
+        }
+
+        if (_stream != null)
+        {
+            await _stream.DisposeAsync();
+        }
+
         _cts?.Dispose();
-        await Task.Yield();
     }
 }


### PR DESCRIPTION
## Summary
- extend `IMessagingTransport` with `IAsyncDisposable`
- add async disposal and graceful shutdown to `NamedPipeTransport` and `AzureServiceBusTransport`
- reuse a single `StreamWriter` in `NamedPipeTransport`

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_688ff395491c832cbdeae29b761572f3