### PR TITLE
Use A2A library types for messaging

### DIFF
--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Agent1/Semantic.Kernel.Agent2AgentProtocol.Example.Agent1.csproj
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Agent1/Semantic.Kernel.Agent2AgentProtocol.Example.Agent1.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
+    <PackageReference Include="A2A" Version="0.1.0-preview.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Semantic.Kernel.Agent2AgentProtocol.Example.Agent2/Semantic.Kernel.Agent2AgentProtocol.Example.Agent2.csproj
+++ b/Semantic.Kernel.Agent2AgentProtocol.Example.Agent2/Semantic.Kernel.Agent2AgentProtocol.Example.Agent2.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
+    <PackageReference Include="A2A" Version="0.1.0-preview.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- rely on `AgentCard` and `Message` from the A2A package
- build and parse payloads via `A2AHelper` without custom serialization
- update agents to send and receive library messages

## Testing
- `dotnet build Semantic.Kernel.Agent2AgentProtocol.Example.sln`

------
https://chatgpt.com/codex/tasks/task_e_68909f4bb5ec832c8abf971a496c2dd1